### PR TITLE
Potential fix for code scanning alert no. 34: Unsigned difference expression compared to zero

### DIFF
--- a/atomspace/opencog/atoms/flow/SplitLink.cc
+++ b/atomspace/opencog/atoms/flow/SplitLink.cc
@@ -67,7 +67,7 @@ ValuePtr SplitLink::rewrap_h(AtomSpace* as, const Handle& base)
 			while (true) {
 				size_t prev = pos;
 				pos = link_str.find_first_of(_sep, pos);
-				if (0 < pos-prev)
+				if (pos > prev)
 				{
 					const std::string& subby(link_str.substr(prev, pos-prev));
 					if (0 < subby.length())
@@ -95,7 +95,7 @@ ValuePtr SplitLink::rewrap_h(AtomSpace* as, const Handle& base)
 	while (true) {
 		size_t prev = pos;
 		pos = name.find_first_of(_sep, pos);
-		if (0 < pos-prev)
+		if (pos > prev)
 		{
 			const std::string& subby(name.substr(prev, pos-prev));
 			if (0 < subby.length())


### PR DESCRIPTION
Potential fix for [https://github.com/OzCog/opencog-unified/security/code-scanning/34](https://github.com/OzCog/opencog-unified/security/code-scanning/34)

To fix this logic error, the comparison `0 < pos-prev` should be replaced with `pos > prev`. This avoids unsigned wraparound and precisely checks that the search has advanced, so there's a legitimate substring to extract. You should apply this fix in both places where this pattern appears: the block that splits `link_str` (line 70) and the second block that splits `name` (line 98). No new includes or external dependencies are required. This preserves the original functionality while ensuring correct string splitting without unsigned underflows.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
